### PR TITLE
NPE in IndexScan() when key is not in the index

### DIFF
--- a/Fallen-8/Fallen8.cs
+++ b/Fallen-8/Fallen8.cs
@@ -650,8 +650,11 @@ namespace NoSQL.GraphDB
             switch (binOp)
             {
                 case BinaryOperator.Equals:
-
-                    index.TryGetValue(out result, literal);
+                    if( ! index.TryGetValue(out result, literal))
+                    {
+                        result = null;
+                        return false;
+                    }
                     break;
 
                 case BinaryOperator.Greater:


### PR DESCRIPTION
The ```IndexScan(BinaryOperator.Equals)``` method throws a NPE when the value is not in the index, because ```index.TryGetValue(out result, literal);``` may end with a null ```result```.
